### PR TITLE
init codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in the repo.
+* @waymobetta @hoffmabc
+#
+# Learn about CODEOWNERS file format: 
+# https://help.github.com/en/articles/about-code-owners
+#


### PR DESCRIPTION
This PR introduces a [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file to manage the repo access.