### PR TITLE
add new rpc methods; (fix) add missing description

### DIFF
--- a/src/rpc/http-methods/get-current-state.md
+++ b/src/rpc/http-methods/get-current-state.md
@@ -2,7 +2,7 @@
 
 > ️️⚠️ Note: This endpoint is not available for local validators.
 
-**Description:** Retrieves the current state: the validator's state (`Init`, `ConnectedToNetwork`, `ReadyToSync`, etc.) and the latest state transition, as type [Instant].
+**Description:** Retrieves the current state of the node, including information about the blockchain and network status.
 
 **Method:** `POST`
 
@@ -27,8 +27,11 @@ http://localhost:9002/
 ```json
 {
   "jsonrpc": "2.0",
-  "result": "",
-  "id": "1"
+  "result": {
+    "state": "Running",
+    "last_state_transition": "2023-10-01T12:00:00Z"
+  },
+  "id": 1
 }
 ```
 

--- a/src/rpc/http-methods/get-current-state.md
+++ b/src/rpc/http-methods/get-current-state.md
@@ -1,5 +1,7 @@
 # `getCurrentState`
 
+> ️️⚠️ Note: This endpoint is not available for local validators.
+
 **Description:** Retrieves the current state: the validator's state (`Init`, `ConnectedToNetwork`, `ReadyToSync`, etc.) and the latest state transition, as type [Instant].
 
 **Method:** `POST`

--- a/src/rpc/http-methods/get-current-state.md
+++ b/src/rpc/http-methods/get-current-state.md
@@ -1,0 +1,34 @@
+# `getCurrentState`
+
+**Description:** Retrieves the current state: the validator's state (`Init`, `ConnectedToNetwork`, `ReadyToSync`, etc.) and the latest state transition, as type [Instant].
+
+**Method:** `POST`
+
+**Parameters:**
+    None.
+
+**Returns:** A `CurrentState` object.
+
+**Request:**
+```bash
+curl -vL POST -H 'Content-Type: application/json' -d '
+{
+    "jsonrpc":"2.0",
+    "id":1,
+    "method":"get_current_state",
+    "params":[]
+}' \
+http://localhost:9002/
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "result": "",
+  "id": "1"
+}
+```
+
+<!-- External -->
+[Instant]: https://doc.rust-lang.org/std/time/struct.Instant.html

--- a/src/rpc/http-methods/get-peers.md
+++ b/src/rpc/http-methods/get-peers.md
@@ -1,5 +1,7 @@
 # `getPeers`
 
+> ️️⚠️ Note: This endpoint is not available for local validators.
+
 **Description:** Retrieves details of a validator's peers: `peer_id`, `time_drift_ms` and the `last_heartbeat` as type, [Instant].
 
 **Method:** `POST`

--- a/src/rpc/http-methods/get-peers.md
+++ b/src/rpc/http-methods/get-peers.md
@@ -1,0 +1,34 @@
+# `getPeers`
+
+**Description:** Retrieves details of a validator's peers: `peer_id`, `time_drift_ms` and the `last_heartbeat` as type, [Instant].
+
+**Method:** `POST`
+
+**Parameters:**
+    None.
+
+**Returns:** An array of `PeerStats`.
+
+**Request:**
+```bash
+curl -vL POST -H 'Content-Type: application/json' -d '
+{
+    "jsonrpc":"2.0",
+    "id":1,
+    "method":"get_peers",
+    "params":[]
+}' \
+http://localhost:9002/
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "result": "",
+  "id": "1"
+}
+```
+
+<!-- External -->
+[Instant]: https://doc.rust-lang.org/std/time/struct.Instant.html

--- a/src/rpc/http-methods/get-peers.md
+++ b/src/rpc/http-methods/get-peers.md
@@ -2,7 +2,7 @@
 
 > ️️⚠️ Note: This endpoint is not available for local validators.
 
-**Description:** Retrieves details of a validator's peers: `peer_id`, `time_drift_ms` and the `last_heartbeat` as type, [Instant].
+**Description:** Retrieves a list of peers currently connected to the node.
 
 **Method:** `POST`
 
@@ -27,8 +27,14 @@ http://localhost:9002/
 ```json
 {
   "jsonrpc": "2.0",
-  "result": "",
-  "id": "1"
+  "result": [
+    {
+      "peer_id": "12D3KooW...",
+      "address": "/ip4/192.168.1.1/tcp/30303",
+      "status": "connected"
+    }
+  ],
+  "id": 1
 }
 ```
 

--- a/src/rpc/http-methods/get-program-accounts.md
+++ b/src/rpc/http-methods/get-program-accounts.md
@@ -2,7 +2,7 @@
 
 > ⚠️ Note: This endpoint is not available for local validators.
 
-Fetches all accounts owned by the specified program ID.
+**Description**: Fetches all accounts owned by the specified program ID.
 
 **Parameters:** `program_id: <byte_array>` - Pubkey of the program to query, as an array of 32 bytes.
 


### PR DESCRIPTION
This PR introduces pages for two new RPC methods as well as includes a missing description field for `get-program-accounts.md`.

Closes: [devrel#19](https://github.com/Arch-Network/devrel/issues/19)